### PR TITLE
Improve the sed command.

### DIFF
--- a/commands/sed.js
+++ b/commands/sed.js
@@ -1,26 +1,51 @@
-function sedStr (str, arg) {
-  let str_ = str;
-  let arg_ = arg;
-  arg_ = arg_.split ('/');
-  if (typeof (arg_[1]) == 'undefined' ||
-    (arg_[0].length < 1 || arg_[1].length < 1)) {
-  } else {
-    try{
-      re = new RegExp (arg_[0], "gi");
-      str_ = str_.replace (re, arg_[1]);
-    } catch (e) {
-      // Hello, smile
+function codePointsFromString (str) {
+  let codePoints = [];
+  for (let index = 0; index < str.length; ++index) {
+    let charCode = str.charCodeAt(index);
+    if ((charCode & 0xfc00) === 0xd800) { // High surrogate.
+      let charCode2 = str.charCodeAt(index + 1);
+      if ((charCode2 & 0xfc00) === 0xdc00) { // Low surrogate.
+        charCode = ((charCode & 0x3ff) << 10) | (charCode2 & 0x3ff) | 0x10000;
+        ++index;
+      }
     }
+    codePoints.push(charCode);
   }
-
-  return str_;
+  return codePoints;
 }
 
-exports.run = function sed (str, arg_arr) {
-  let clean = str;
-  for (i in arg_arr) {
-    clean.embed.description = sedStr (clean.embed.description, arg_arr[i]);
+const commandFunctions = {
+  's': function substitute (first, second, flags) {
+    flags = flags.toLowerCase().replace(/[^gimuy]/g, '');
+    first = new RegExp(first, flags);
+    return str => str.replace(first, second);
+  },
+  'y': function transliterate (first, second, flags) {
+    first = codePointsFromString(first);
+    second = codePointsFromString(second);
+    return str => String.fromCodePoint.apply(null, codePointsFromString(str).map(function (codePoint) {
+      let index = first.indexOf(codePoint);
+      return (index >= 0 && index < second.length) ? second[index] : codePoint;
+    }));
   }
-  return clean;
+};
+
+function commandsFromString (args) {
+  const regexp = /([sy])([\ud800-\udbff][\udc00-\udfff]|\S)(.*?)\2(.*?)\2(\S*)/g;
+  let commands = [];
+  let match;
+  while ((match = regexp.exec(args)) !== null) {
+    let func = commandFunctions[match[1]];
+    func && commands.push(func.apply(null, match.slice(3)));
+  }
+  return commands;
 }
 
+exports.run = function (str, args) {
+  try {
+    if (args instanceof Array) args = args.join(' ');
+    return commandsFromString(args).reduce((result, func) => func(result), str);
+  } catch (err) {
+    return `Error: ${err.message}`;
+  }
+};


### PR DESCRIPTION
This PR makes the syntax more closely match that of the actual `sed` program.

The current `search/replace` syntax would become `s/search/replace/g`.  Note several things:

- The explicit mention of the substitute command (`s`).
- The additional separator characters (`/`).
- And the global flag (`g`).

The separator can be any character the user wants.  It is simply whatever symbol immediately follows the command.  So, `s|search|replace|g` and `s%search%replace%g` would also work.

Since the specification of flags is required, it does enable the use of `i` for case-insensitive matching.

It should be noted that since the regular expression replacement is done via the `String.prototype.replace` method, references to captured groups are done using `$n`, where _n_ is the number of the group.  To reference the entire matched expression, use `$&`.

---

In addition to the substitute command, the transliterate command (`y`) from `sed` is also supported in this PR.  The usage is `y/first/second/` where letters from the first set are replaced by letters in the second set based on position.  For example, `y/abc/123/` would convert `Abacus` into `A213us`.