### PR TITLE
Updates to sed usage and implementation.

### DIFF
--- a/commands/checksudo.js
+++ b/commands/checksudo.js
@@ -1,4 +1,4 @@
-const utils = require('../lib/utils.js');
+// const utils = require('../lib/utils.js');
 
 exports.run = function (msg, args, usertype) {
   msg.reply('You are a ' + usertype + ' user.');

--- a/commands/figlet.js
+++ b/commands/figlet.js
@@ -1,6 +1,6 @@
 const figlet = require('figlet');
 
-const utils = require('../lib/utils.js');
+// const utils = require('../lib/utils.js');
 
 exports.run = function (msg, args, usertype) {
   msg.channel.send('```\n' + figlet.textSync(args.join(' ')) + '\n```');

--- a/commands/fortune.js
+++ b/commands/fortune.js
@@ -1,6 +1,6 @@
 const fortunes = require('fortunes');
 
-const utils = require('../lib/utils.js');
+// const utils = require('../lib/utils.js');
 
 exports.run = function (msg, args, usertype) {
   fortunes.search(function (results) {

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,4 +1,4 @@
-const utils = require('../lib/utils.js');
+// const utils = require('../lib/utils.js');
 
 exports.run = function (msg) {
   msg.channel.send('``` * !info @user: gives you the set info on a user.\n * !chinfo <info>: changes your current info (**WARNING** This does NOT append, it OVERWRITES).\n * !rminfo: removes your current info.```\n\nThere are other fluff commands, but those are left for you to discover :wink:');

--- a/commands/info.js
+++ b/commands/info.js
@@ -1,5 +1,5 @@
 const jsonfile = require('jsonfile');
-const utils = require('../lib/utils.js');
+// const utils = require('../lib/utils.js');
 
 var db;
 

--- a/commands/rminfo.js
+++ b/commands/rminfo.js
@@ -11,11 +11,11 @@ exports.run = function (msg, args, usertype) {
   } else if (usertype === 'regular') {
     msg.reply('archbot: rminfo: permission denied');
   } else if (usertype === 'sudoer') {
-    if (args[0].substr(2, 1) === '!') {
-      userId = args[0].substr(3, 18);
-    } else {
-      userId = args[0].substr(2, 18);
-    }
+    // if (args[0].substr(2, 1) === '!') {
+    //   userId = args[0].substr(3, 18);
+    // } else {
+    //   userId = args[0].substr(2, 18);
+    // }
     delete db[msg.author.id];
     msg.channel.send('Info removed.');
   }

--- a/commands/sed.js
+++ b/commands/sed.js
@@ -51,7 +51,7 @@ exports.run = function (obj, args) {
     if (args instanceof Array) args = args.join(' ');
     let str = obj.embed.description;
     str = commandsFromString(args).reduce((result, func) => func(result), str);
-    obj.embed.description = str;
+    obj.embed.description = str.substr(0, 2048);
     return obj;
   } catch (err) {
     return `Error: ${err.message}`;

--- a/commands/sed.js
+++ b/commands/sed.js
@@ -39,7 +39,8 @@ function commandsFromString (args) {
       func && commands.push(func.apply(null, match.slice(3)));
     } else if (match[6]) {
       let func = commandFunctions['s'];
-      func && commands.push(func.apply(null, match.slice(6).map(x => x.replace(/\\(.)/g, '$1'))));
+      let args = match.slice(6).map(x => x.replace(/\\(.)/g, '$1'));
+      func && commands.push(func.apply(null, args.concat('g')));
     }
   }
   return commands;
@@ -55,4 +56,10 @@ exports.run = function (obj, args) {
   } catch (err) {
     return `Error: ${err.message}`;
   }
+};
+
+exports.test = {
+  codePointsFromString,
+  commandFunctions,
+  commandsFromString
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const gulp = require('gulp');
+
+// Are we running within continuous integration?
+const CI = process.env.CI === 'true';
+
+// File globs.
+const entrypoint = require('./package.json')['main'];
+const globs = {
+  sources: [entrypoint, 'lib/**/*.js', 'commands/**/*.js'],
+  tests: ['test/**/*.test.js'],
+  testsSetup: ['./test/setup.js']
+};
+const all = Array.prototype.concat.apply([], Object.keys(globs).map(x => globs[x]));
+
+// Default meta-task.
+gulp.task('default', ['watch']);
+
+// Test meta-task.
+const runAllTasks = function (tasksToRun, callback) {
+  let anyErrors = false;
+  const runNextTask = function (result) {
+    anyErrors = anyErrors || (result && result.err);
+    if (tasksToRun.length) {
+      gulp.start(tasksToRun.shift());
+    } else {
+      gulp.removeListener('task_stop', runNextTask);
+      gulp.removeListener('task_err', runNextTask);
+      if (anyErrors) {
+        let error = new Error('One or more tasks failed.  (See above for details)');
+        error.showStack = false;
+        callback(error);
+      } else {
+        callback();
+      }
+    }
+  };
+  gulp.on('task_stop', runNextTask);
+  gulp.on('task_err', runNextTask);
+  runNextTask();
+};
+
+gulp.task('test', function (done) {
+  runAllTasks(['semistandard-lint', 'mocha-test'], done);
+});
+
+// Watch meta-task.
+const watch = require('gulp-watch');
+const batch = require('gulp-batch');
+
+gulp.task('watch', function () {
+  watch(all, { ignoreInitial: false }, batch(function (events, done) {
+    gulp.start('test', done);
+  }));
+});
+
+// Semistandard-based linting task.
+const semistandard = require('gulp-semistandard');
+
+gulp.task('semistandard-lint', function () {
+  return gulp.src(all.concat('./gulpfile.js'))
+    .pipe(semistandard())
+    .pipe(semistandard.reporter('default', {
+      breakOnError: true,
+      quiet: true
+    }));
+});
+
+// Mocha-based testing task.
+const mocha = require('gulp-mocha');
+
+gulp.task('mocha-test', function () {
+  return gulp.src(globs.tests, { read: false })
+    .pipe(mocha({
+      require: globs.testsSetup,
+      reporter: CI ? 'spec' : 'nyan'
+    }));
+});

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ client.on('message', msg => {
   let args = msg.content.split(' ').slice(1);
   let usertype = 'regular';
 
-  console.log (`command: ${command}\nargs: ${args}\n`);
+  console.log(`command: ${command}\nargs: ${args}\n`);
   let errMesg = 'archbot: command not found: ' + command;
 
   if (command === 'sudo') {
@@ -34,14 +34,14 @@ client.on('message', msg => {
   }
 
   if (typeof (pasta[command]) !== 'undefined') {
-    let regPasta = JSON.parse (JSON.stringify (pasta[command])); //fuck JS! 
-    let SED = require ('./commands/sed.js');
+    let regPasta = JSON.parse(JSON.stringify(pasta[command])); // fuck JS!
+    let SED = require('./commands/sed.js');
     if (Object.prototype.toString.call(regPasta) === '[object Object]') {
-      let clean = SED.run (regPasta, args);
+      let clean = SED.run(regPasta, args);
       msg.channel.send(clean);
     } else if (Object.prototype.toString.call(regPasta) === '[object Array]') {
       regPasta.forEach(function (part) {
-        let clean = SED.run (part, args);
+        let clean = SED.run(part, args);
         msg.channel.send(clean);
       });
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Bot for archlinux discord",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",
@@ -22,5 +22,16 @@
     "figlet": "^1.2.0",
     "fortunes": "0.0.3",
     "jsonfile": "^3.0.0"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "gulp": "^3.9.1",
+    "gulp-batch": "^1.0.5",
+    "gulp-mocha": "^3.0.1",
+    "gulp-semistandard": "^1.0.0",
+    "gulp-watch": "^4.3.11",
+    "mocha": "^3.2.0",
+    "sinon": "^2.1.0",
+    "sinon-chai": "^2.9.0"
   }
 }

--- a/test/commands/sed.test.js
+++ b/test/commands/sed.test.js
@@ -116,5 +116,10 @@ describe('sed', function () {
       run(input, '(.)a/$1i');
       expect(input).to.have.deep.property('embed.description', 'Abici');
     });
+    it('truncates output to 2048 characters', function () {
+      const args = './$&$&$&$&$&$&$&$& ./$&$&$&$&$&$&$&$& ./$&$&$&$&$&$&$&$&';
+      let subject = run(input, args).embed.description;
+      expect(subject).to.have.lengthOf(2048);
+    });
   });
 });

--- a/test/commands/sed.test.js
+++ b/test/commands/sed.test.js
@@ -1,0 +1,120 @@
+/* eslint-env mocha */
+/* global expect */
+'use strict';
+
+describe('sed', function () {
+  const sed = require('../../commands/sed').test;
+
+  describe('.codePointsFromString', function () {
+    const func = sed.codePointsFromString || (x => x);
+    it('handles an empty string', function () {
+      expect(func('')).to.deep.equal([]);
+    });
+    it('handles a string without surrogate pairs', function () {
+      expect(func('Hi!')).to.deep.equal([0x48, 0x69, 0x21]);
+    });
+    it('handles a string with surrogate pairs', function () {
+      expect(func('😀🚀')).to.deep.equal([0x1f600, 0x1f680]);
+    });
+  });
+
+  describe('.commandFunctions.substitute', function () {
+    const func = sed.commandFunctions && sed.commandFunctions['s'] || (x => x);
+    it('returns a function', function () {
+      expect(func('a', 'b', 'i')).to.be.a('function');
+    });
+    it('does not throw if no flags are provided', function () {
+      expect(function () { return func('a', 'b'); }).to.not.throw;
+    });
+  });
+
+  describe('.commandFunctions.transliterate', function () {
+    const func = sed.commandFunctions && sed.commandFunctions['y'] || (x => x);
+    it('returns a function', function () {
+      expect(func('a', 'b')).to.be.a('function');
+    });
+    it('maps characters from the source to the destination', function () {
+      expect(func('abc', '123')('cab')).to.equal('312');
+    });
+    it('does not change characters not found in the source', function () {
+      expect(func('abc', '123')('cat')).to.equal('31t');
+    });
+    it('ignores source characters that have no corresponding destination', function () {
+      expect(func('ab', 'c')('ab')).to.equal('cb');
+    });
+    it('handles strings with surrogate pairs', function () {
+      expect(func('X😀', '🚀Y')('X😀!')).to.equal('🚀Y!');
+    });
+  });
+
+  describe('.commandsFromString', function () {
+    const func = sed.commandsFromString || (x => x);
+    it('handles an empty string', function () {
+      expect(func('')).to.deep.equal([]);
+    });
+    it('parses a substitution of the form "s/pattern/replacement/flags"', function () {
+      let subject = func('s/[ab]+/"$&"/i');
+      expect(subject).to.be.an('array').with.lengthOf(1);
+      expect(subject[0]).to.be.a('function');
+      expect(subject[0]('Abaca')).to.equal('"Aba"ca');
+    });
+    it('parses a substitution of the form "pattern/replacement"', function () {
+      let subject = func('[ab]+/"$&"');
+      expect(subject).to.be.an('array').with.lengthOf(1);
+      expect(subject[0]).to.be.a('function');
+      expect(subject[0]('Abaca')).to.equal('A"ba"c"a"');
+    });
+    it('parses a transliteration of the form "y/source/destination/"', function () {
+      let subject = func('y/abc/123/');
+      expect(subject).to.be.an('array').with.lengthOf(1);
+      expect(subject[0]).to.be.a('function');
+      expect(subject[0]('Abaca')).to.equal('A2131');
+    });
+    it('parses multiple commands in a single string', function () {
+      let subject = func('s/[ab]+/"$&"/i [ab]+/"$&" y/abc/123/');
+      expect(subject).to.be.an('array').with.lengthOf(3);
+    });
+    it('supports custom separators with the new syntax', function () {
+      let subject = func('s|[ab]+|/$&/|i');
+      expect(subject).to.be.an('array').with.lengthOf(1);
+      expect(subject[0]).to.be.a('function');
+      expect(subject[0]('Abaca')).to.equal('/Aba/ca');
+    });
+    it('supports escapement with the old syntax', function () {
+      let subject = func('\\\\\\\\/\\ \\/\\ ');
+      expect(subject).to.be.an('array').with.lengthOf(1);
+      expect(subject[0]).to.be.a('function');
+      expect(subject[0]('a\\b')).to.equal('a / b');
+    });
+    it('ignores extraneous characters', function () {
+      let subject = func('before abc/123 after');
+      expect(subject).to.be.an('array').with.lengthOf(1);
+      expect(subject[0]).to.be.a('function');
+      expect(subject[0]('Labcoat')).to.equal('L123oat');
+    });
+  });
+
+  describe('run', function () {
+    const run = require('../../commands/sed').run;
+    let input;
+    beforeEach(function () {
+      input = { embed: { description: 'Abaca' } };
+    });
+
+    it('does not throw when given bad regular expression patterns', function () {
+      // NOTE: JavaScript does not support lookbehind.
+      let subject = () => run(input, 's/(?<=a)b/c/');
+      expect(subject).to.not.throw;
+      expect(subject()).to.match(/invalid regular expression/i);
+    });
+    it('supports an array of arguments', function () {
+      const args = ['s/[ab]+/"$&"/i', '[ab]+/"$&"', 'y/abc/123/'];
+      expect(run(input, args)).to.have.deep.property('embed.description', '"A"21""3"1"');
+    });
+    it('modifies the description within the input object', function () {
+      expect(input).to.have.deep.property('embed.description', 'Abaca');
+      run(input, '(.)a/$1i');
+      expect(input).to.have.deep.property('embed.description', 'Abici');
+    });
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+
+chai.config.includeStack = true;
+chai.use(require('sinon-chai'));
+
+// Export globals for use by individual unit tests.
+global.chai = chai;
+global.expect = chai.expect;
+global.sinon = sinon;


### PR DESCRIPTION
- Added support for old syntax due to complaints.  As such, `abc/def` is parsed and read the same as `s/abc/def/g`.  Note that the global flag is default for the old style, however it is still case sensitive.
- Added support for escaping when using the old syntax.  The backslash (`\`) is used to escape, and any character may follow it, including the backslash.  This permits escaping whitespace as well as the separator symbol.  That is, `\a\/b/\ !` is parsed as read the same as `s|a/b| !|g`.  Note that because a backslash has special meaning when on the pattern side of the expression, it must be doubled for a literal backslash.  However, each backslash must, itself, be escaped, resulting in four backslashes: `\\\\/!`, equivalent to `s/\\/!/g`.
- Changed the main regex to only match valid flags rather than accepting all symbols and then filtering them.
- *Considered* but did not enable global flag by default for new syntax.  With the old syntax now supported and always global, it makes sense for the new syntax to require explicit flags.

---
### ![Mocha](https://cldup.com/xFVFxOioAU.svg) This PR is also adding a proper unit test framework.  
**NOTE:** Be sure to run `npm install` again to pick up the development dependencies.

- Added mocha/chai/sinon BDD testing support.
- Added semistandard linting support.
- Added gulp task runner: use `gulp watch` to automatically run tests/linter when files change.
- Added unit tests for `sed.js`.
- Fixed numerous semistandard style errors.  (Most were cases where `utils.js` was brought in but never used.)
- Fixed bug where global flag was not actually being applied with the old syntax.  (Yay for unit tests!)