### PR TITLE
Fix issue with missing descriptions and sed.

### DIFF
--- a/commands/sed.js
+++ b/commands/sed.js
@@ -48,6 +48,7 @@ function commandsFromString (args) {
 
 exports.run = function (obj, args) {
   try {
+    if (!obj.embed.description) return obj;
     if (args instanceof Array) args = args.join(' ');
     let str = obj.embed.description;
     str = commandsFromString(args).reduce((result, func) => func(result), str);

--- a/test/commands/sed.test.js
+++ b/test/commands/sed.test.js
@@ -121,5 +121,13 @@ describe('sed', function () {
       let subject = run(input, args).embed.description;
       expect(subject).to.have.lengthOf(2048);
     });
+    it('ignores input that is missing a description', function () {
+      input.embed = {};
+      expect(input).to.not.have.deep.property('embed.description');
+      let subject = run(input, '');
+      expect(subject).to.have.property('embed');
+      expect(subject).to.not.have.deep.property('embed.description');
+      expect(input).to.not.have.deep.property('embed.description');
+    });
   });
 });


### PR DESCRIPTION
- Not all pastas have a description member in the embed.  Make sure to ignore those cases, since there is nothing to work on.