### PR TITLE
Message chunking support

### DIFF
--- a/lib/fun.rb
+++ b/lib/fun.rb
@@ -39,7 +39,20 @@ module Fun
           usage: "[text]",
           min_args: 1) \
   do |event, *args|
-    "```" + Cowsay.say(args.join(' '), 'cow') + "```"
+    inputtext = args.join(' ')
+    renderedtext = Cowsay.say(inputtext, 'cow')
+    chunkedtext = ""
+    until renderedtext.empty?
+      sliced = renderedtext.slice(0..1990)
+      lastindex = sliced.length - 1
+      lastline = sliced.lines.last
+      unless lastline.end_with? '\n' or renderedtext.length == sliced.length
+        lastindex -= lastline.length
+      end
+      chunkedtext << "```\n" + renderedtext.slice!(0..lastindex)+ "\n```" \
+              + " " * lastline.length + "\n"
+    end
+    chunkedtext
   end
 
   command(:me,

--- a/lib/patches.rb
+++ b/lib/patches.rb
@@ -1,0 +1,30 @@
+#allow output from commands to exceed 2000 chars
+module Discordrb::Commands
+  class CommandBot
+     def execute_chain(chain, event)
+      t = Thread.new do
+        @event_threads << t
+        Thread.current[:discordrb_name] = "ct-#{@current_thread += 1}"
+        begin
+          debug("Parsing command chain #{chain}")
+          result = @attributes[:advanced_functionality] ? CommandChain.new(chain, self).execute(event) : simple_execute(chain, event)
+          result = event.drain_into(result)
+      
+          if event.file
+            event.send_file(event.file, caption: result)
+          else
+            unless result.nil? || result.empty?
+              Discordrb.split_message(result).each do |chunk|
+                event.respond chunk
+              end 
+            end
+          end
+        rescue => e
+          log_exception(e)
+        ensure
+          @event_threads.delete(t)
+        end
+      end
+    end
+  end
+end

--- a/main.rb
+++ b/main.rb
@@ -5,6 +5,7 @@ require 'figlet'
 require 'cowsay'
 require 'fortune_gem'
 
+require_relative 'lib/patches'
 require_relative 'lib/utilities'
 require_relative 'lib/fun'
 require_relative 'lib/admin'


### PR DESCRIPTION
commands can now output more than 2000 chars while maintaining the ability to pipe commands.