### PR TITLE
Added dockerfile to containerize ArchBot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.4-alpine3.6
+
+RUN mkdir /usr/src/app
+
+COPY . /usr/src/app
+
+WORKDIR /usr/src/app
+
+RUN apk update && \
+    apk add ruby-dev build-base curl-dev && \
+    bundle install --gemfile=/usr/src/app/Gemfile && \
+    rm -rf /var/cache/apk/*
+
+ENTRYPOINT ["./main.rb"]

--- a/main.rb
+++ b/main.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require 'discordrb'
 require 'fullwidth'
 require 'yaml'


### PR DESCRIPTION
Yep, ArchBot can be on the whale now. As an advantage it's easier to deploy and can be automatically kept up to date with a service like watchtower. To launch the container: `docker build . -t archbot && docker run -dit -v /path/to/your/config.yaml:/usr/src/app archbot`